### PR TITLE
Fix props visibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2345,7 +2345,7 @@ dependencies = [
 
 [[package]]
 name = "modx"
-version = "0.1.0-1"
+version = "0.1.2"
 dependencies = [
  "dioxus",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modx"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "GPL-3.0-or-later"
 description = "A way to handle states with structs in Dioxus inspired by mobx"

--- a/examples/pub.rs
+++ b/examples/pub.rs
@@ -1,0 +1,18 @@
+use dioxus::prelude::*;
+mod pub_store;
+use pub_store::CounterStore;
+
+
+fn main() {
+    launch(app);
+}
+
+fn app() -> Element {
+    let mut store = CounterStore::new();
+    rsx! {
+        button { onclick: move |_| store.inc(), "+1" }
+        button { onclick: move |_| store.dec(), "-1" }
+        "{store.count}"
+    }
+}
+

--- a/examples/pub_store.rs
+++ b/examples/pub_store.rs
@@ -1,0 +1,19 @@
+use {dioxus::prelude::*, modx::store};
+
+#[store(Default)]
+pub struct CounterStore {
+    pub count: i64,
+}
+
+impl CounterStore {
+    pub fn inc(&mut self) {
+        self.count += 1;
+    }
+
+    pub fn dec(&mut self) {
+        self.count -= 1;
+    }
+}
+
+#[allow(dead_code)]
+fn main() {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,7 +206,7 @@ pub fn store(_: OriginalTokenStream, item: OriginalTokenStream) -> OriginalToken
             // Implement default
             quote! {
                 impl #struct_name {
-                    pub fn new() -> #struct_name {
+                    pub fn new() -> Self {
                         let mut default_struct = #struct_name {
                             #(#default_values)*
                         };
@@ -252,7 +252,7 @@ pub fn store(_: OriginalTokenStream, item: OriginalTokenStream) -> OriginalToken
             quote! {
                 #structprops
                 impl #struct_name {
-                    pub fn new(props: #structprops_name) -> #struct_name {
+                    pub fn new(props: #structprops_name) -> Self {
                         let mut default_struct = #struct_name {
                             #(#default_values)*
                         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,7 +237,7 @@ pub fn store(_: OriginalTokenStream, item: OriginalTokenStream) -> OriginalToken
             // Implement default
             quote! {
                 #[derive(Debug)]
-                struct #structprops_name {
+                #struct_visibility struct #structprops_name {
                     #(#struct_props_fields)*
                 }
                 impl #struct_name {


### PR DESCRIPTION
The visibility of `{structprops_name}Props` should be aligned with the `{structprops_name}` one.

To avoid to make the `{structprops_name}Props` attributes visible, a `{structprops_name}Props::new` method has been added.